### PR TITLE
feat: --all-branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 <img align="right" src="logo.svg">
 
-Autorebase automatically rebases all of your feature branches onto `master`. If conflicts are found it will rebase to the last commit that doesn't cause conflicts. Currently it will rebase all branches that don't have an upstream. You don't need to switch to any branch, the only limitation is that a branch that is checked out and not clean will not be rebased (though I may add that in future).
+Autorebase automatically rebases all of your feature branches onto `master`. If conflicts are found it will rebase to the last commit that doesn't cause conflicts.
+By default, branches with an upstream are excluded.
+You don't need to switch to any branch, the only limitation is that a branch that is checked out and not clean will not be rebased (though I may add that in future).
 
 Here is a demo. Before autorebase we have a number of old feature branches.
 
@@ -32,7 +34,7 @@ Just run `autorebase` in your repo. This will perform the following actions
 
 1. Update `master`, by pulling it with `--ff-only` unless you have it checked out with pending changes.
 2. Create a temporary work tree inside `.git/autorebase` (this is currently never deleted but you can do it manually with `git worktree remove autorebase_worktree`).
-3. Get the list of branches that have no upstream, and aren't checked out with pending changes.
+3. Get the list of branches that have no upstream (except with `--all-branches`), and aren't checked out with pending changes.
 4. For each branch:
     1. Try to rebase it onto `master`.
     2. If that fails due to conflicts, abort and try to rebase it as far as possible. There are two strategies for this (see below).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,7 +605,6 @@ fn get_current_branch_or_commit(worktree_path: &Path) -> Result<BranchOrCommit> 
         return Ok(BranchOrCommit::Branch(branch));
     }
 
-
     let commit = get_commit_hash(worktree_path, "HEAD")?;
     Ok(BranchOrCommit::Commit(commit))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub fn autorebase(
     repo_path: &Path,
     onto_branch: &str,
     slow_conflict_detection: bool,
+    include_all_branches: bool,
 ) -> Result<()> {
     // Check the git version. `git switch` was introduced in 2.23.
     if git_version(repo_path)?.as_slice() < &[2, 23] {
@@ -83,7 +84,7 @@ pub fn autorebase(
     for branch in all_branches.iter() {
         if branch.branch == onto_branch {
             eprintln!("    - {} (target branch)", branch.branch.blue().bold());
-        } else if branch.upstream.is_some() {
+        } else if !include_all_branches && branch.upstream.is_some() {
             eprintln!(
                 "    - {} (skipping because it has an upstream)",
                 branch.branch.bold()
@@ -103,7 +104,7 @@ pub fn autorebase(
         .iter()
         .filter(|branch| {
             branch.branch != onto_branch
-                && branch.upstream.is_none()
+                && (include_all_branches || branch.upstream.is_none())
                 && !matches!(&branch.worktree, Some(worktree) if !worktree.clean)
         })
         .collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,9 @@ struct CliOptions {
     /// target branch directly
     #[argh(switch)]
     slow: bool,
+    /// include branches which have an upstream, the default is to exclude these
+    #[argh(switch)]
+    all_branches: bool,
 }
 
 fn main() -> Result<()> {
@@ -35,7 +38,12 @@ fn run() -> Result<()> {
     // Find the repo dir in the same way git does.
     let repo_path = get_repo_path()?;
 
-    autorebase(&repo_path, &options.onto, options.slow)?;
+    autorebase(
+        &repo_path,
+        &options.onto,
+        options.slow,
+        options.all_branches,
+    )?;
 
     Ok(())
 }

--- a/tests/tests/all_branches.rs
+++ b/tests/tests/all_branches.rs
@@ -1,0 +1,81 @@
+use std::collections::BTreeMap;
+
+use autorebase::autorebase;
+
+use crate::{commit_graph, utils::*};
+
+fn with_include(include_all_branches: bool) -> BTreeMap<String, CommitGraphNode> {
+    git_fixed_dates();
+
+    let root = commit("First")
+        .write("a.txt", "hello")
+        .child(commit("Second").write("a.txt", "world").branch("master"))
+        .child(
+            commit("Third")
+                .write("b.txt", "foo")
+                .branch_with_upstream("other_main", "master"),
+        )
+        .child(commit("wip").write("c.txt", "foo").branch("wip"));
+
+    let repo = build_repo(&root, Some("master"));
+
+    let repo_dir = repo.path();
+
+    print_git_log_graph(&repo_dir);
+
+    autorebase(repo_dir, "master", false, include_all_branches).expect("error autorebasing");
+
+    print_git_log_graph(&repo_dir);
+
+    get_repo_graph(&repo_dir).expect("error getting repo graph")
+}
+
+#[test]
+fn skips_branches() {
+    let graph = with_include(false);
+
+    let expected_graph = commit_graph!(
+        "6781625b397d4f2eeb6da4b1fea570052683629f": CommitGraphNode {
+            parents: ["d3591307bd5590f14ae24d03ab41121ab94e2a90"],
+            refs: {"other_main"},
+        },
+        "a6de41485a5af44adc18b599a63840c367043e39": CommitGraphNode {
+            parents: ["d3591307bd5590f14ae24d03ab41121ab94e2a90"],
+            refs: {"master"},
+        },
+        "d3591307bd5590f14ae24d03ab41121ab94e2a90": CommitGraphNode {
+            parents: [],
+            refs: {""},
+        },
+        "f7aad7ec74984d4cd89090e572de921d5f9d1fc4": CommitGraphNode {
+            parents: ["a6de41485a5af44adc18b599a63840c367043e39"],
+            refs: {"wip"}
+        }
+    );
+    assert_eq!(graph, expected_graph);
+}
+
+#[test]
+fn includes_branches() {
+    let graph = with_include(true);
+
+    let expected_graph = commit_graph!(
+        "089f39ba0066fd2380da7dbe5201ec4b13f01b4a": CommitGraphNode {
+            parents: ["a6de41485a5af44adc18b599a63840c367043e39"],
+            refs: {"other_main"}
+        },
+        "a6de41485a5af44adc18b599a63840c367043e39": CommitGraphNode {
+            parents: ["d3591307bd5590f14ae24d03ab41121ab94e2a90"],
+            refs: {"master"}
+        },
+        "d3591307bd5590f14ae24d03ab41121ab94e2a90": CommitGraphNode {
+            parents: [],
+            refs: {""}
+        },
+        "f7aad7ec74984d4cd89090e572de921d5f9d1fc4": CommitGraphNode {
+            parents: ["a6de41485a5af44adc18b599a63840c367043e39"],
+            refs: {"wip"}
+        }
+    );
+    assert_eq!(graph, expected_graph);
+}

--- a/tests/tests/basic.rs
+++ b/tests/tests/basic.rs
@@ -1,5 +1,5 @@
-use autorebase::autorebase;
 use crate::{commit_graph, utils::*};
+use autorebase::autorebase;
 
 // Test building a repo using `build_repo`.
 #[test]

--- a/tests/tests/basic.rs
+++ b/tests/tests/basic.rs
@@ -63,7 +63,7 @@ fn basic_autorebase(slow_conflict_detection: bool) {
 
     print_git_log_graph(&repo_dir);
 
-    autorebase(repo_dir, "master", slow_conflict_detection).expect("error autorebasing");
+    autorebase(repo_dir, "master", slow_conflict_detection, false).expect("error autorebasing");
 
     print_git_log_graph(&repo_dir);
 

--- a/tests/tests/basic_conflict.rs
+++ b/tests/tests/basic_conflict.rs
@@ -34,7 +34,7 @@ fn conflict(slow_conflict_detection: bool) {
 
     print_git_log_graph(&repo_dir);
 
-    autorebase(repo_dir, "master", slow_conflict_detection).expect("error autorebasing");
+    autorebase(repo_dir, "master", slow_conflict_detection, false).expect("error autorebasing");
 
     print_git_log_graph(&repo_dir);
 

--- a/tests/tests/basic_conflict.rs
+++ b/tests/tests/basic_conflict.rs
@@ -1,5 +1,5 @@
-use autorebase::autorebase;
 use crate::{commit_graph, utils::*};
+use autorebase::autorebase;
 
 // Single branch that cannot be rebased all the way to `master` commit due to conflicts.
 #[test]

--- a/tests/tests/checked_out.rs
+++ b/tests/tests/checked_out.rs
@@ -1,6 +1,6 @@
+use crate::{commit_graph, utils::*};
 use autorebase::autorebase;
 use std::fs;
-use crate::{commit_graph, utils::*};
 
 // Check we can rebase with the current checked out branch.
 #[test]

--- a/tests/tests/checked_out.rs
+++ b/tests/tests/checked_out.rs
@@ -27,7 +27,7 @@ fn checkedout_clean(slow_conflict_detection: bool) {
 
     print_git_log_graph(&repo_dir);
 
-    autorebase(repo_dir, "master", slow_conflict_detection).expect("error autorebasing");
+    autorebase(repo_dir, "master", slow_conflict_detection, false).expect("error autorebasing");
 
     print_git_log_graph(&repo_dir);
 
@@ -88,7 +88,7 @@ fn checkedout_dirty(slow_conflict_detection: bool) {
 
     print_git_log_graph(&repo_dir);
 
-    autorebase(repo_dir, "master", slow_conflict_detection).expect("error autorebasing");
+    autorebase(repo_dir, "master", slow_conflict_detection, false).expect("error autorebasing");
 
     print_git_log_graph(&repo_dir);
 

--- a/tests/tests/conflict_resume.rs
+++ b/tests/tests/conflict_resume.rs
@@ -1,7 +1,7 @@
+use crate::{commit_graph, utils::*};
 use autorebase::autorebase;
 use git_commands::git;
 use std::fs;
-use crate::{commit_graph, utils::*};
 
 // Single branch that cannot be rebased all the way to `master` commit due to conflicts,
 // However we then change master so there's no conflict, but when we run `autorebase`
@@ -162,7 +162,6 @@ fn conflict_resume(slow_conflict_detection: bool) {
 
     // Check out master again so `wip` can be autorebased.
     git(&["checkout", "master"], repo_dir).expect("error checking out master");
-
 
     // Ok if we run `autorebase` is should succesfully rebase to master.
 

--- a/tests/tests/conflict_resume.rs
+++ b/tests/tests/conflict_resume.rs
@@ -40,7 +40,7 @@ fn conflict_resume(slow_conflict_detection: bool) {
 
     print_git_log_graph(&repo_dir);
 
-    autorebase(repo_dir, "master", slow_conflict_detection).expect("error autorebasing");
+    autorebase(repo_dir, "master", slow_conflict_detection, false).expect("error autorebasing");
 
     print_git_log_graph(&repo_dir);
 
@@ -98,7 +98,7 @@ fn conflict_resume(slow_conflict_detection: bool) {
 
     print_git_log_graph(&repo_dir);
 
-    autorebase(repo_dir, "master", true).expect("error autorebasing");
+    autorebase(repo_dir, "master", true, false).expect("error autorebasing");
 
     print_git_log_graph(&repo_dir);
 
@@ -167,7 +167,7 @@ fn conflict_resume(slow_conflict_detection: bool) {
 
     print_git_log_graph(&repo_dir);
 
-    autorebase(repo_dir, "master", true).expect("error autorebasing");
+    autorebase(repo_dir, "master", true, false).expect("error autorebasing");
 
     print_git_log_graph(&repo_dir);
 

--- a/tests/tests/mod.rs
+++ b/tests/tests/mod.rs
@@ -1,5 +1,5 @@
-mod basic_conflict;
 mod basic;
+mod basic_conflict;
 mod checked_out;
 mod conflict_resume;
 mod multiple_branches;

--- a/tests/tests/mod.rs
+++ b/tests/tests/mod.rs
@@ -1,3 +1,4 @@
+mod all_branches;
 mod basic;
 mod basic_conflict;
 mod checked_out;

--- a/tests/tests/multiple_branches.rs
+++ b/tests/tests/multiple_branches.rs
@@ -27,7 +27,7 @@ fn multiple_branches(slow_conflict_detection: bool) {
 
     print_git_log_graph(&repo_dir);
 
-    autorebase(repo_dir, "master", slow_conflict_detection).expect("error autorebasing");
+    autorebase(repo_dir, "master", slow_conflict_detection, false).expect("error autorebasing");
 
     print_git_log_graph(&repo_dir);
 

--- a/tests/tests/multiple_branches.rs
+++ b/tests/tests/multiple_branches.rs
@@ -1,5 +1,5 @@
-use autorebase::autorebase;
 use crate::{commit_graph, utils::*};
+use autorebase::autorebase;
 
 // Basic test but there is more than one branch that needs to be rebased.
 #[test]

--- a/tests/tests/multiple_refs_on_branch.rs
+++ b/tests/tests/multiple_refs_on_branch.rs
@@ -31,7 +31,7 @@ fn multiple_branches(slow_conflict_detection: bool) {
 
     print_git_log_graph(&repo_dir);
 
-    autorebase(repo_dir, "master", slow_conflict_detection).expect("error autorebasing");
+    autorebase(repo_dir, "master", slow_conflict_detection, false).expect("error autorebasing");
 
     print_git_log_graph(&repo_dir);
 

--- a/tests/tests/multiple_refs_on_branch.rs
+++ b/tests/tests/multiple_refs_on_branch.rs
@@ -1,5 +1,5 @@
-use autorebase::autorebase;
 use crate::{commit_graph, utils::*};
+use autorebase::autorebase;
 
 // Basic test but there are multiple chained refs on the branch.
 #[test]

--- a/tests/tests/random.rs
+++ b/tests/tests/random.rs
@@ -1,5 +1,5 @@
-use autorebase::autorebase;
 use crate::utils::*;
+use autorebase::autorebase;
 
 // Test randomly generated repos.
 #[test]
@@ -41,7 +41,6 @@ fn random_test_many_fast() {
 }
 
 fn random_test_many(slow_conflict_detection: bool) {
-
     // This takes about 0.5 seconds per iteration.
     for _ in 0..10 {
         random_test(slow_conflict_detection);

--- a/tests/tests/random.rs
+++ b/tests/tests/random.rs
@@ -23,7 +23,7 @@ fn random_test(slow_conflict_detection: bool) {
 
     print_git_log_graph(&repo_dir);
 
-    autorebase(repo_dir, "master", slow_conflict_detection).expect("error autorebasing");
+    autorebase(repo_dir, "master", slow_conflict_detection, false).expect("error autorebasing");
 
     print_git_log_graph(&repo_dir);
 

--- a/tests/utils/random_repo.rs
+++ b/tests/utils/random_repo.rs
@@ -31,7 +31,7 @@ pub fn random_repo(allow_merges: bool) -> CommitDescription {
             let branch_name = format!("branch_{}", rng.gen_range(0..1000000));
             if !branches.contains(&branch_name) {
                 branches.insert(branch_name.clone());
-                commit.branches.push(branch_name);
+                commit.branches.push((branch_name, None));
             }
         }
 
@@ -51,7 +51,7 @@ pub fn random_repo(allow_merges: bool) -> CommitDescription {
 
         // So that we guarantee something is `master`, the first tip will be master.
         if !branches.contains("master") {
-            commit.branches.push("master".to_owned());
+            commit.branches.push(("master".to_owned(), None));
             branches.insert("master".to_owned());
         }
 

--- a/tests/utils/random_repo.rs
+++ b/tests/utils/random_repo.rs
@@ -1,4 +1,3 @@
-
 use super::CommitDescription;
 use rand::Rng;
 use std::collections::HashSet;
@@ -12,7 +11,11 @@ pub fn random_repo(allow_merges: bool) -> CommitDescription {
 
     // This uses recursion so we need to set a maximum depth to avoid stack overflows.
 
-    fn randomise_commit(commit: &mut CommitDescription, branches: &mut HashSet<String>, depth: u32) {
+    fn randomise_commit(
+        commit: &mut CommitDescription,
+        branches: &mut HashSet<String>,
+        depth: u32,
+    ) {
         let mut rng = rand::thread_rng();
 
         // Randomly set the name, branch, contents, etc.
@@ -20,7 +23,10 @@ pub fn random_repo(allow_merges: bool) -> CommitDescription {
         // The filename and contents are drawn from a small distribution to
         // give a reasonable chance of writing the same file to make conflicts,
         // or serendipitously eliminating conflicts.
-        commit.changes.insert(format!("{}.txt", rng.gen_range(0..8)), Some(format!("{}", rng.gen_range(0..8))));
+        commit.changes.insert(
+            format!("{}.txt", rng.gen_range(0..8)),
+            Some(format!("{}", rng.gen_range(0..8))),
+        );
         if rng.gen_bool(0.1) {
             let branch_name = format!("branch_{}", rng.gen_range(0..1000000));
             if !branches.contains(&branch_name) {
@@ -48,7 +54,6 @@ pub fn random_repo(allow_merges: bool) -> CommitDescription {
             commit.branches.push("master".to_owned());
             branches.insert("master".to_owned());
         }
-
 
         for _ in 0..num_children {
             // Add a child commit


### PR DESCRIPTION
A flag, `--all-branches`, which causes us to also rebase branches with an upstream.

I don't use the `upstream` feature (i.e. have branches pushed to `matching`), so whether things have an upstream is pretty much random.